### PR TITLE
Modal: toggle full/simplified command, copy toast, scoped warnings

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -19,20 +19,25 @@
       <p v-html="t('message.install_macos')"></p>
       <p v-html="t('message.instructions')"></p>
 
-      <div class="warnings">
+      <!-- Ces avertissements ne concernent que l'installation complète :
+           la version simplifiée n'installe ni brew ni les Xcode CLT. -->
+      <div class="warnings" v-if="!simplified">
         <p class="warning" v-html="t('message.warnings.interactive')"></p>
         <p class="warning" v-html="t('message.warnings.gatekeeper')"></p>
       </div>
 
-      <textarea readonly id="install-command" v-auto-size>{{
-        commandWithBrew
-      }}</textarea>
+      <textarea
+        readonly
+        id="install-command"
+        v-auto-size
+        :value="currentCommand"
+      ></textarea>
       <div class="buttons">
         <button
           type="button"
           class="btn"
           :class="[$i18n.locale === 'fr' ? 'btn-gold' : 'btn-green']"
-          @click="copyWithBrew"
+          @click="copyCommand"
         >
           {{ t("message.copy") }}
         </button>
@@ -40,18 +45,24 @@
           type="button"
           class="btn"
           :class="[$i18n.locale === 'fr' ? 'btn-green' : 'btn-gold']"
-          @click="copyWithoutBrew"
+          @click="simplified = !simplified"
         >
-          {{ t("message.already_brew") }}
+          {{ simplified ? t("message.full_command") : t("message.already_brew") }}
         </button>
       </div>
+
+      <transition name="toast">
+        <p class="toast" v-if="copied" role="status" aria-live="polite">
+          {{ t("message.copied") }}
+        </p>
+      </transition>
       <slot></slot>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, onUnmounted } from "vue";
+import { computed, defineComponent, onMounted, onUnmounted, ref } from "vue";
 import { store } from "../store";
 import { useI18n } from "vue-i18n";
 import autoSize from "../directives/autoSize";
@@ -153,22 +164,32 @@ export default defineComponent({
     // Command without brew (for users who already have it)
     const commandWithoutBrew = bundleCommand;
 
-    const copyWithBrew = () => {
-      navigator.clipboard.writeText(commandWithBrew.trimEnd());
+    // Toggled by the "I already have brew!" button: swaps what the textarea
+    // shows (and what gets copied) instead of copying a hidden variant.
+    const simplified = ref(false);
+    const currentCommand = computed(() =>
+      (simplified.value ? commandWithoutBrew : commandWithBrew).trimEnd()
+    );
+
+    const copied = ref(false);
+    let copiedTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const copyCommand = async () => {
+      await navigator.clipboard.writeText(currentCommand.value);
+      copied.value = true;
+      clearTimeout(copiedTimeout);
+      copiedTimeout = setTimeout(() => (copied.value = false), 2000);
     };
 
-    const copyWithoutBrew = () => {
-      navigator.clipboard.writeText(commandWithoutBrew.trimEnd());
-    };
+    onUnmounted(() => clearTimeout(copiedTimeout));
 
     return {
       store,
       closeModal,
-      installBrew,
-      copyWithBrew,
-      copyWithoutBrew,
-      commandWithBrew,
-      commandWithoutBrew,
+      copyCommand,
+      copied,
+      simplified,
+      currentCommand,
       t,
     };
   },
@@ -246,6 +267,30 @@ textarea {
 .buttons {
   display: flex;
   gap: 1em;
+}
+
+.toast {
+  position: absolute;
+  bottom: 1em;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 0.5em 1.25em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.85);
+  pointer-events: none;
+}
+
+.toast-enter-active,
+.toast-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
 }
 
 .warnings {

--- a/src/directives/autoSize.ts
+++ b/src/directives/autoSize.ts
@@ -5,23 +5,29 @@ declare global {
   }
 }
 
+const resize = (ta: HTMLTextAreaElement) => {
+  ta.style.height = "auto";
+  ta.style.height = `${ta.scrollHeight + 2}px`;
+};
+
 const autoSize = {
   mounted(ta: HTMLTextAreaElement) {
-    const resize = () => {
-      ta.style.height = "auto";
-      ta.style.height = `${ta.scrollHeight + 2}px`;
-    };
+    const onResize = () => resize(ta);
 
     // Ajustement initial
-    resize();
+    onResize();
 
     // Ajustement lors du redimensionnement de la fenêtre
-    window.addEventListener("resize", resize);
+    window.addEventListener("resize", onResize);
 
     // Nettoyage lors du démontage
     ta.__resizeCleanup__ = () => {
-      window.removeEventListener("resize", resize);
+      window.removeEventListener("resize", onResize);
     };
+  },
+  // Le contenu change quand on bascule entre commande complète et simplifiée
+  updated(ta: HTMLTextAreaElement) {
+    resize(ta);
   },
   unmounted(ta: HTMLTextAreaElement) {
     if (ta.__resizeCleanup__) {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -45,7 +45,9 @@ const messages = {
       instructions:
         "Copy then paste the following command in the terminal and press <kbd>⮐</kbd> to make magic happen",
       copy: "Copy the command",
+      copied: "Command copied!",
       already_brew: "I already have brew!",
+      full_command: "Show the full command",
       warnings: {
         interactive:
           "📝 The installation will ask you to: <strong>1.</strong> Press Enter to confirm <strong>2.</strong> Enter your admin password (sudo)",
@@ -103,7 +105,9 @@ const messages = {
       instructions:
         "Copiez puis collez le code suivant dans le terminal et appuyez sur <kbd>⮐</kbd> pour que la magie opère",
       copy: "Copier la commande",
+      copied: "Commande copiée !",
       already_brew: "J'ai déjà brew !",
+      full_command: "Voir la commande complète",
       warnings: {
         interactive:
           "📝 L'installation vous demandera de : <strong>1.</strong> Appuyer sur Entrée pour confirmer <strong>2.</strong> Entrer votre mot de passe administrateur (sudo)",


### PR DESCRIPTION
Follow-up to #9. Three UX fixes on the install modal.

## 1. "I already have brew!" now switches the displayed command

Previously the button copied a variant the user never saw — the textarea always showed the full script. It now swaps what is displayed (and therefore what gets copied), and its label toggles to **"Show the full command"** to get back.

| | textarea |
|---|---|
| full | `#!/bin/bash` + pre-checks + CLT + brew install + `brew bundle` |
| simplified | just the `brew bundle --file=- <<'BREWFILE'` block |

## 2. "Command copied!" toast

The copy button copies whatever is currently displayed and shows a toast for 2s, with a fade transition. It carries `role="status"` / `aria-live="polite"` so screen readers announce it. The timeout is cleared on unmount.

## 3. Warnings hidden in simplified mode

The sudo-prompt and Gatekeeper warnings only describe the full install. The simplified version installs neither brew nor the Xcode CLT, so both are noise there.

## i18n

New keys `message.copied` and `message.full_command`, in **EN and FR**:

| key | en | fr |
|---|---|---|
| `copied` | Command copied! | Commande copiée ! |
| `full_command` | Show the full command | Voir la commande complète |

## Implementation notes

The textarea moved from `{{ }}` interpolation to a `:value` binding, since its content is now reactive. The `autoSize` directive gained an `updated` hook so the height recomputes when the command changes — without it, the box stayed at the full script's height after switching to the short one.

## Testing

- `npm run build` (incl. `vue-tsc -b`) passes.
- Driven in a real browser (Playwright) in **both locales**: toggle swaps the command and the button label, warnings appear/disappear, textarea resizes, toast shows the right string. Toast position checked against the modal box — inside it, no overlap with the buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)